### PR TITLE
allow a LIST of initial items to be passed to the constructor

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Tie::CPHash.
 
+1.07   2014-02-27
+	- Add constructor LIST support
+
 1.06   2013-11-09
 	- no functional changes
 	- release tests moved to xt/

--- a/lib/Tie/CPHash.pm
+++ b/lib/Tie/CPHash.pm
@@ -25,19 +25,23 @@ use vars qw($VERSION);
 #=====================================================================
 # Package Global Variables:
 
-$VERSION = '1.06';
+$VERSION = '1.07';
 # This file is part of {{$dist}} {{$dist_version}} ({{$date}})
 
 #=====================================================================
 # Tied Methods:
 #---------------------------------------------------------------------
-# TIEHASH classname
+# TIEHASH classname LIST
 #      The method invoked by the command `tie %hash, classname'.
 #      Associates a new hash instance with the specified class.
 
 sub TIEHASH
 {
-    bless {}, $_[0];
+    my $self = bless {}, $_[0];
+    for ( my $i = 1; $i < @_; $i+=2 ) {
+        $self->STORE( $_[$i], $_[$i+1] )
+    }
+    return $self;
 } # end TIEHASH
 
 #---------------------------------------------------------------------

--- a/t/10-CPHash.t
+++ b/t/10-CPHash.t
@@ -15,12 +15,12 @@
 #---------------------------------------------------------------------
 #########################
 
-use Test::More tests => 16;
+use Test::More tests => 18;
 BEGIN { use_ok('Tie::CPHash') };
 
 #########################
 
-my(%h,$j,$test);
+my(%h,$j,%i,$test);
 
 tie(%h, 'Tie::CPHash');
 ok(1, 'tied %h');
@@ -68,6 +68,10 @@ SKIP: {
   skip 'SCALAR added in Perl 5.8.3', 1 unless $] >= 5.008003;
   ok(!scalar %h, 'SCALAR now empty');
 };
+
+tie( %i, 'Tie::CPHash', Hello => 'World' );
+is( $i{hello}, 'World' );
+is( tied(%i)->key('hello'), 'Hello' );
 
 # Local Variables:
 # mode: perl


### PR DESCRIPTION
This allows the user to construct a CPHash by doing:

```
tie my %hash, 'Tie::CPHash', (
    some => 'initial', 
    value => 'set',
);
```
